### PR TITLE
added cast to Date for zoo objects. Added tests

### DIFF
--- a/R/class-twdtwTimeSeries.R
+++ b/R/class-twdtwTimeSeries.R
@@ -77,6 +77,13 @@ setMethod("initialize",
       .Object@labels = factor(NULL)
       if(!missing(timeseries)){
         if(is(timeseries, "zoo")) timeseries = list(timeseries)
+        # make sure the time is Date
+        timeseries <- lapply(timeseries, function(x){
+          if(!is(index(x), "Date")){
+            index(x) <- as.Date(index(x))
+          }
+          return(x)
+        })
         .Object@timeseries = timeseries
         .Object@labels = factor( paste0("ts",seq_along(timeseries)) ) 
         if(!is.null(names(timeseries))) .Object@labels = factor(names(timeseries))

--- a/tests/run-all.R
+++ b/tests/run-all.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(dtwSat)
+
+test_check("dtwSat")

--- a/tests/testthat/test_twdtwApply.R
+++ b/tests/testthat/test_twdtwApply.R
@@ -1,0 +1,31 @@
+# test_twdtwApply.R
+
+#require(testthat)
+#require(dtwSat)
+
+# get the pattern's data
+pname.list <- list()
+pdata.list <- list()
+pindex.list <- list()
+for(i in 1:length(patterns.list)){
+  pname.list[[i]] <- names(patterns.list)[[i]]
+  pdata.list[[i]] <- coredata(patterns.list[[i]])
+  pindex.list[[i]] <- index(patterns.list[[i]])
+}
+
+patterns.list.Pct <- list()
+patterns.list.Plt <- list()
+for(i in 1:length(patterns.list)){
+  pind <- as.POSIXct(pindex.list[[i]])
+  patterns.list.Pct[[i]] <- zoo(x = pdata.list[[i]], order.by = pind)
+  pind <- as.POSIXlt(pindex.list[[i]])
+  patterns.list.Plt[[i]] <- zoo(x = pdata.list[[i]], order.by = pind)
+}
+
+patterns_ts = twdtwTimeSeries(patterns.list)
+patterns_ts.Pct = twdtwTimeSeries(patterns.list.Pct)
+patterns_ts.Plt = twdtwTimeSeries(patterns.list.Plt)
+
+expect_true(is(index(patterns_ts[[1]]), "Date"))
+expect_true(is(index(patterns_ts.Pct[[1]]), "Date"))
+expect_true(is(index(patterns_ts.Plt[[1]]), "Date"))


### PR DESCRIPTION
Good afternoon. When the patterns' zoo objects use POSIXct or POSIXlt instead of Date, the machine runs out of memory. I added a cast form POSIXct or POSIXlt to Date in the class "twdtwTimeSeries" line 81. This avoids the issue. Besides, I added tests to make sure the cast is happening. Bests