### PR TITLE
Fix several typos in R scripts

### DIFF
--- a/R/class-twdtwAssessment.R
+++ b/R/class-twdtwAssessment.R
@@ -28,9 +28,9 @@
 #'
 #' @section Slots :
 #' \describe{
-#'  \item{\code{accuracySummary}:}{Overall Accuracy, User's Accuracy, Produce's Accuracy, 
+#'  \item{\code{accuracySummary}:}{Overall Accuracy, User's Accuracy, Producer's Accuracy, 
 #'  Error Matrix (confusion matrix), and Estimated Area, considering all time periods.}
-#'  \item{\code{accuracyByPeriod}:}{Overall Accuracy, User's Accuracy, Produce's Accuracy, 
+#'  \item{\code{accuracyByPeriod}:}{Overall Accuracy, User's Accuracy, Producer's Accuracy, 
 #'  Error Matrix (confusion matrix), and Estimated Area, for each time periods independently 
 #'  from each other.}
 #'  \item{\code{data}:}{A \code{\link[sp]{SpatialPointsDataFrame}} with sample ID, period,
@@ -39,7 +39,7 @@
 #' }
 #' 
 #' @details
-#' If the twdtwRaster is unprojected (longitude/latitude) the estimated area is sum of the approximate 
+#' If the twdtwRaster is unprojected (longitude/latitude) the estimated area is the sum of the approximate 
 #' surface area in km2 of each cell (pixel). If the twdtwRaster is projected the estimated area is calculated 
 #' using the the pixel resolution in the map unit.
 #'

--- a/R/class-twdtwRaster.R
+++ b/R/class-twdtwRaster.R
@@ -27,7 +27,7 @@
 #' in the format of "YYYY-MM-DD".
 #'
 #' @param layers a vector with the names of the \code{Raster*} objects 
-#' passed to "\code{...}". If not informed the layers are set to the 
+#' passed to "\code{...}". If not provided the layers are set to the 
 #' names of objects in "\code{...}". 
 #' 
 #' @param labels a vector of class \code{\link[base]{character}} with 
@@ -41,25 +41,25 @@
 #' @param doy A \code{\link[raster]{RasterBrick-class}} or 
 #' \code{\link[raster]{RasterStack-class}} with a sequence of days of the year for each pixel. 
 #' \code{doy} must have the same spatial and temporal extents as the Raster* objects passed to \code{...}.
-#' If \code{doy} is not informed then at least one Raster* object must be passed through \code{...}.
+#' If \code{doy} is not provided then at least one Raster* object must be passed through \code{...}.
 #'  
-#' @param filepath A character. The path to save the raster time series. If informed the 
+#' @param filepath A character. The path to save the raster time series. If provided the 
 #' function saves a raster file for each Raster* object in the list, \emph{i.e} one file 
-#' for each time series. This way the function retrieves an list of 
+#' for each time series. This way the function retrieves a list of 
 #' \code{\link[raster]{RasterBrick-class}}. It is useful when the time series are 
-#' originally stores in separated files. See details. 
+#' originally stored in separated files. See details. 
 #'
 #' @param object an object of class twdtwRaster.
 #'
 #' @param x an object of class twdtwRaster.
 #'
-#' @details The performance the functions \code{\link[dtwSat]{twdtwApply}} and 
+#' @details The performance of the functions \code{\link[dtwSat]{twdtwApply}} and 
 #' \code{\link[dtwSat]{getTimeSeries}} is improved if the Raster* objects are connected 
 #' to files with the whole time series for each attribute. 
 #'
 #' @section Slots :
 #' \describe{
-#'  \item{\code{timeseries}:}{A list of multi-layers Raster* objects 
+#'  \item{\code{timeseries}:}{A list of multi-layer Raster* objects 
 #'        with the satellite image time series.}
 #'  \item{\code{timeline}:}{A vector of class \code{\link[base]{date}} 
 #'        with dates of the satellite images in \code{timeseries}.}
@@ -77,7 +77,7 @@
 #' \code{\link[dtwSat]{twdtwTimeSeries-class}}
 #'
 #' @examples 
-#' # Creating new object of class twdtwTimeSeries 
+#' # Creating a new object of class twdtwTimeSeries 
 #' evi = brick(system.file("lucc_MT/data/evi.tif", package="dtwSat"))
 #' timeline = scan(system.file("lucc_MT/data/timeline", package="dtwSat"), what="date")
 #' rts = new("twdtwRaster", timeseries = evi, timeline = timeline)
@@ -196,7 +196,7 @@ setMethod(f = "twdtwRaster",
               }
               I = which(sapply(x, is, "RasterBrick") | sapply(x, is, "RasterStack") | sapply(x, is, "RasterLayer"))
               if(length(I) < 1)
-                stop("there is no Raster* objects in the list of arguments")
+                stop("There are no Raster* objects in the list of arguments")
               # Split arguments 
               timeseries = x[I]
               dotargs = x[-I]
@@ -212,7 +212,7 @@ creat.twdtwRaster = function(timeseries, timeline, doy, layers, labels, levels, 
   if(!is.null(doy))
     nl = c(nlayers(doy), nl)
   if(any(nl!=length(timeline)))
-    stop("raster objects do not have the same length as the timeline")
+    stop("Raster objects do not have the same length as the timeline")
   
   res = timeseries
   # Save a single file (complete time series) for each raster attribute 

--- a/R/class-twdtwTimeSeries.R
+++ b/R/class-twdtwTimeSeries.R
@@ -17,7 +17,7 @@
 #' @aliases twdtwTimeSeries
 #' @author Victor Maus, \email{vwmaus1@@gmail.com}
 #'
-#' @description Class for set of irregular time series.
+#' @description Class for setting irregular time series.
 #' 
 #' @param ... \code{\link[dtwSat]{twdtwTimeSeries}} objects, 
 #' \code{\link[zoo]{zoo}} objects or a list of \code{\link[zoo]{zoo}} objects.
@@ -38,7 +38,7 @@
 #' \code{\link[dtwSat]{twdtwApply}}
 #'
 #' @examples 
-#' # Creating new object of class twdtwTimeSeries  
+#' # Creating a new object of class twdtwTimeSeries  
 #' ptt = new("twdtwTimeSeries", timeseries = MOD13Q1.patterns.list, 
 #'            labels = names(MOD13Q1.patterns.list))
 #' class(ptt)

--- a/R/createPatterns.R
+++ b/R/createPatterns.R
@@ -22,11 +22,11 @@
 #' @param x an object of class \code{\link[dtwSat]{twdtwTimeSeries}}.
 #' 
 #' @param from A character or \code{\link[base]{Dates}} object in the format 
-#' "yyyy-mm-dd". If not informed it is equal to the smallest date of the 
+#' "yyyy-mm-dd". If not provided it is equal to the smallest date of the 
 #' first element in x. See details. 
 #'  
 #' @param to A \code{\link[base]{character}} or \code{\link[base]{Dates}} 
-#' object in the format "yyyy-mm-dd". If not informed it is equal to the 
+#' object in the format "yyyy-mm-dd". If not provided it is equal to the 
 #' greatest date of the first element in x. See details. 
 #' 
 #' @param attr A vector character or numeric. The attributes in \code{x} to be used. 
@@ -40,14 +40,14 @@
 #' @param formula A formula. Argument to pass to \code{\link[mgcv]{gam}}. 
 #' 
 #' @param ... other arguments to pass to the function \code{\link[mgcv]{gam}} in the 
-#' packege \pkg{mgcv}.
+#' package \pkg{mgcv}.
 #' 
 #' @return an object of class \code{\link[dtwSat]{twdtwTimeSeries}} 
 #' 
 #'
 #' @details The hidden assumption is that the temporal pattern is a cycle the repeats itself 
 #' within a given time interval. Therefore, all time series samples in \code{x} are aligned 
-#' to each other keeping their respective sequence of days of the year. The function fits a 
+#' with each other, keeping their respective sequence of days of the year. The function fits a 
 #' Generalized Additive Model (GAM) to the aligned set of samples.  
 #' 
 #' @seealso 
@@ -93,7 +93,7 @@ setMethod("createPatterns", "twdtwTimeSeries",
                   stop("missing formula")
                 vars = all.vars(formula)
                 
-                # Split samples according their labels 
+                # Split samples according to their labels 
                 if(split) {
                     levels = as.character(levels(x))
                     labels = as.character(labels(x))

--- a/R/data.R
+++ b/R/data.R
@@ -22,11 +22,11 @@
 #' 
 #' @description This dataset has a list of patterns with the phenological cycle of: Soybean,
 #' Cotton, and Maize. These time series are based on the MODIS product 
-#' MOD13Q1 250 m 16 days [1]. The patterns were build from ground truth samples of each 
+#' MOD13Q1 250 m 16 days [1]. The patterns were built from ground truth samples of each 
 #' crop using Generalized Additive Models (GAM), see \link[dtwSat]{createPatterns}.
 #' 
 #' @docType data
-#' @format A named \code{list} of 3 \link[zoo]{zoo} objects, ''Soybean'', ''Cotton'', 
+#' @format A named \code{list} of three \link[zoo]{zoo} objects, ''Soybean'', ''Cotton'', 
 #' and ''Maize'', whose indices are \code{\link[base]{Dates}} in the format ''yyyy-mm-dd''.
 #' Each node has 6 attributes: ''ndvi'', ''evi'', ''red'', ''nir'', ''blue'', 
 #' and ''mir''.
@@ -77,10 +77,10 @@
 #' @title Data: Labels of the satellite time series in MOD13Q1.ts 
 #' @author Victor Maus, \email{vwmaus1@@gmail.com}
 #' 
-#' @description This labels are based on field work.
+#' @description These labels are based on field work.
 #' 
 #' @docType data
-#' @format An object of class \link[base]{data.frame}, whose attributas are: 
+#' @format An object of class \link[base]{data.frame}, whose attributes are: 
 #' the label of the crop class ''label'', the start of the crop period ''from'',
 #' and the end of the crop period ''to''. The dates are in the format ''yyyy-mm-dd''.
 #' 
@@ -117,13 +117,13 @@
 "MOD13Q1.ts.list"
 
 
-#' @title Data: patterns time series
+#' @title Data: Pattern time series
 #' @author Victor Maus, \email{vwmaus1@@gmail.com}
 #' 
 #' @description This dataset has a list of patterns with the phenological cycle of: Water,
 #' Cotton-Fallow, Forest, Low vegetation, Pasture, Soybean-Cotton, Soybean-Maize, Soybean-Millet, 
 #' Soybean-Sunflower, and Wetland. These time series are based on the MODIS product 
-#' MOD13Q1 250 m 16 days [1]. The patterns were build from ground truth samples of each 
+#' MOD13Q1 250 m 16 days [1]. The patterns were built from ground truth samples of each 
 #' crop using Generalized Additive Models (GAM), see \link[dtwSat]{createPatterns}.
 #' 
 #' @docType data

--- a/R/getTimeSeries.R
+++ b/R/getTimeSeries.R
@@ -22,7 +22,7 @@ setGeneric("getPatterns", function(object, ...) standardGeneric("getPatterns"))
 #' 
 #' @description Get time series from objects of class twdtw*.
 #' 
-#' @param object an object of class of class twdtw*.
+#' @param object an object of class twdtw*.
 #'
 #' @param y a \code{\link[base]{data.frame}} whose attributes are: longitude, 
 #' latitude, the start ''from'' and the end ''to'' of the time interval 
@@ -32,7 +32,7 @@ setGeneric("getPatterns", function(object, ...) standardGeneric("getPatterns"))
 #' \code{object}. 
 #' 
 #' @param id.labels a numeric or character with an column name from \code{y} to 
-#' be used as samples labels. Optional.
+#' be used as sample labels. Optional.
 #' 
 #' @param labels character vector with time series labels. For signature 
 #' \code{\link[dtwSat]{twdtwRaster}} this argument can be used to set the 
@@ -60,6 +60,7 @@ setGeneric("getPatterns", function(object, ...) standardGeneric("getPatterns"))
 #' patt = twdtwTimeSeries(MOD13Q1.patterns.list)
 #' mat = twdtwApply(x=ts, y=patt)
 #' getTimeSeries(mat, 2)
+#' 
 #' ## This example creates a twdtwRaster object and extract time series from it. 
 #'
 #' # Creating objects of class twdtwRaster with evi and ndvi time series 
@@ -73,7 +74,7 @@ setGeneric("getPatterns", function(object, ...) standardGeneric("getPatterns"))
 #'                          from = "2007-09-01", to = "2013-09-01")
 #' prj_string = "+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0"
 #' 
-#' ## Extract time series 
+#' # Extract time series 
 #' ts = getTimeSeries(rts, y = ts_location, proj4string = prj_string)
 #'  
 #' autoplot(ts[[1]], facets = NULL) + xlab("Time") + ylab("Value")
@@ -135,9 +136,9 @@ extractTimeSeries.twdtwRaster = function(x, y){
   # Check if the coordinates are over the raster extent
   pto = .getPointsOverRaster(x, y)
   if(length(pto)<1)
-    stop("extents do not overlap")
+    stop("Extents do not overlap")
   if(length(pto)<length(y))
-    warning(paste("raster extent does not overlap samples:",paste(pto, collapse = ",")), call. = FALSE)
+    warning(paste("Raster extent does not overlap samples:",paste(pto, collapse = ",")), call. = FALSE)
   
   # Extract time series 
   ts_list = lapply(as.list(x), FUN = extract, y = y[pto,])
@@ -151,7 +152,7 @@ extractTimeSeries.twdtwRaster = function(x, y){
 
 .extractTimeSeries = function(p, pto, x, y, timeline){
   s = y[pto[p],]
-  # Check if the sample time interval overlaps the raster time series 
+  # Check if the sample time interval overlaps with the raster time series 
   from  = try(as.Date(s$from))
   to    = try(as.Date(s$to))
   dates = timeline
@@ -167,7 +168,7 @@ extractTimeSeries.twdtwRaster = function(x, y){
   layer =  which.min( abs(from - dates))
   nl    =  which.min( abs(to   - dates)) - layer
   if(nl<=0){
-    warning(paste("time period of sample ",pto[p]," does not overlap rester time series"), call. = FALSE)
+    warning(paste("Time period of sample ",pto[p]," does not overlap rester time series"), call. = FALSE)
     return(NULL)
   }
   # Extract raster values 

--- a/R/linearWeight.R
+++ b/R/linearWeight.R
@@ -23,7 +23,7 @@
 #' @param b numeric. The intercept of the line. 
 #' 
 #' @docType methods
-#' @return An \code{\link[base]{function}} object.
+#' @return A \code{\link[base]{function}} object.
 #' 
 #' @details The linear \code{linearWeight} and \code{logisticWeight} weight functions 
 #' can be passed to \code{\link[dtwSat]{twdtwApply}} through the argument \code{weight.fun}.

--- a/R/logisticWeight.R
+++ b/R/logisticWeight.R
@@ -23,7 +23,7 @@
 #' @param beta numeric. The midpoint of logistic weight.
 #' 
 #' @docType methods
-#' @return An \code{\link[base]{function}} object.
+#' @return A \code{\link[base]{function}} object.
 #' 
 #' @details The linear \code{linearWeight} and \code{logisticWeight} weight functions 
 #' can be passed to \code{\link[dtwSat]{twdtwApply}} through the argument \code{weight.fun}. 

--- a/R/methods.R
+++ b/R/methods.R
@@ -417,7 +417,7 @@ setMethod("crop",
 
 #' @inheritParams twdtwRaster-class
 #' @rdname twdtwRaster-class
-#' @param obj object of cless twdtwRaster 
+#' @param obj object of class twdtwRaster. 
 #' @export
 setMethod("coordinates", 
           signature = signature("twdtwRaster"),
@@ -450,7 +450,7 @@ show.twdtwTimeSeries = function(object){
 show.twdtwMatches = function(object){
   cat("An object of class \"twdtwMatches\"\n")
   cat("Number of time series:",length(object@timeseries),"\n")
-  cat("Number of Alignments:",length(object),"\n")
+  cat("Number of alignments:",length(object),"\n")
   cat("Patterns labels:",as.character(labels(object@patterns)),"\n")
   invisible(NULL)
 }
@@ -460,10 +460,10 @@ show.twdtwRaster = function(object){
   cat("An object of class \"twdtwRaster\"\n")
   cat("Time series layers:",coverages(object),"\n")
   cat("Time range:",paste(min(object@timeline)),"...",paste(max(object@timeline)),"\n")
-  cat("dimensions:",dim(object),"(nlayers, nrow, ncol, length)\n")
-  cat("resolution:",res(object)," (x, y)\n")
-  cat("extent    :",as.vector(extent(object)), "(xmin, xmax, ymin, ymax)\n")
-  cat("coord.ref.:",projection(object),"\n") 
+  cat("Dimensions:",dim(object),"(nlayers, nrow, ncol, length)\n")
+  cat("Resolution:",res(object)," (x, y)\n")
+  cat("Extent    :",as.vector(extent(object)), "(xmin, xmax, ymin, ymax)\n")
+  cat("Coord.ref.:",projection(object),"\n") 
   invisible(NULL)
 }
 
@@ -507,7 +507,7 @@ show.twdtwCrossValidation = function(object){
   invisible(NULL)
 }
 
-# Project raster which belong to a twdtwRaster object 
+# Project raster which belongs to a twdtwRaster object 
 projecttwdtwRaster.twdtwRaster = function(x, to, ...){
   x@timeseries = lapply(x@timeseries, projectRaster, to, ...)
   x

--- a/R/miscellaneous.R
+++ b/R/miscellaneous.R
@@ -2,12 +2,12 @@
 #' @title Get dates from year and day of the year
 #' @author Victor Maus, \email{vwmaus1@@gmail.com}
 #' 
-#' @description This function retrieves the date corresponding to the ginven 
+#' @description This function retrieves the date corresponding to the given 
 #' year and day of the year.
 #' 
-#' @param year An vector with the years.
-#' @param doy An vector with the day of the year. 
-#' It must have the same lenght as \code{year}.
+#' @param year A vector with the years.
+#' @param doy A vector with the day of the year. 
+#' It must have the same length as \code{year}.
 #' 
 #' @docType methods
 #' 
@@ -41,7 +41,7 @@ getDatesFromDOY = function(year, doy){
 #' @param object \code{\link[dtwSat]{twdtwTimeSeries}} objects, 
 #' \code{\link[zoo]{zoo}} objects or a list of \code{\link[zoo]{zoo}} objects.
 #' 
-#' @param year the base year to shit the time series. 
+#' @param year the base year to shift the time series to. 
 #' 
 #' @seealso 
 #' \code{\link[dtwSat]{twdtwTimeSeries-class}}
@@ -109,7 +109,7 @@ shiftDates.twdtwTimeSeries = function(x, year){
   if(!is.null(id.labels) & !is.null(labels)){
     I = which(!is.na(match(as.character(y$label), as.character(labels))))
     if(length(I)<1) 
-      stop("there is no matches between id.labels and labels")
+      stop("There are no matches between id.labels and labels")
   } else if(!is.null(labels)) { 
     y$label = as.character(labels)
   }

--- a/R/plot.R
+++ b/R/plot.R
@@ -140,7 +140,7 @@ setMethod("plot", signature(x = "twdtwRaster"), function(x, type="maps", ...) .P
          time.labels = format(as.Date(time.levels, "date.%Y.%m.%d"), "%Y")
             
       if(length(time.levels)!=length(time.labels))
-        stop("time.levels and time.labels have different length")
+        stop("time.levels and time.labels have different lengths")
         
       if(is.null(layers)) {
         if(any(coverages(x)=="Distance")){
@@ -181,7 +181,7 @@ setMethod("plot", signature(x = "twdtwRaster"), function(x, type="maps", ...) .P
         
       
       if(length(time.levels)!=length(time.labels))
-        stop("time.levels and time.labels have different length")
+        stop("time.levels and time.labels have different lengths")
       
       # if(length(time.levels)>16){
       #   time.levels = time.levels[1:16]
@@ -207,7 +207,7 @@ setMethod("plot", signature(x = "twdtwRaster"), function(x, type="maps", ...) .P
         class.colors = brewer.pal(length(class.levels), "Set3")
       
       if(length(class.levels)!=length(class.labels))
-        stop("class.levels and class.labels have different length")  
+        stop("class.levels and class.labels have different lengths")  
 
       names(time.labels)  = time.levels
       names(time.levels)  = time.labels

--- a/R/plotAccuracy.R
+++ b/R/plotAccuracy.R
@@ -14,13 +14,13 @@
 #' area in the map units or km2 for no project raster. Default is TRUE.
 #' 
 #' @param category.name a character vector defining the class names. If NULL
-#' then use the classe names in the object \code{x}. Default is NULL.
+#' the class names in the object \code{x} are used. Default is NULL.
 #' 
 #' @param category.type a character defining the categories type "numeric" 
-#' or "letter", if NULL then use the class names. Default is NULL. 
+#' or "letter", if NULL the class names are used. Default is NULL. 
 #' 
 #' @param conf.int confidence level (0-1) for interval estimation of the population mean.
-#' for details see \code{\link[Hmisc]{smean.cl.normal}}. Used if \code{x} is 
+#' For details see \code{\link[Hmisc]{smean.cl.normal}}. Used if \code{x} is 
 #' \code{\link[dtwSat]{twdtwCrossValidation}}.
 #' 
 #' @return A \link[ggplot2]{ggplot} object.
@@ -49,7 +49,7 @@ plotAccuracy = function(x, perc=TRUE, conf.int=.95, time.labels=NULL,
     if(class(x)=="twdtwAssessment"){
       gp = .plotAssessmentAccuracy(x, perc, time.labels, category.name, category.type)
     } else {
-      stop("class of x is not twdtwAssessment or twdtwCrossValidation")
+      stop("Class of x is not twdtwAssessment or twdtwCrossValidation")
     }
   } 
   

--- a/R/plotAlignments.R
+++ b/R/plotAlignments.R
@@ -24,7 +24,7 @@
 #' @param timeseries.labels the label or index of the time series.
 #' Default is 1. 
 #' @param patterns.labels a vector with labels of the patterns. If not 
-#' declared the function will plot the alignments for all patterna in \code{x}.
+#' declared the function will plot the alignments for all patterns in \code{x}.
 #' @param attr An \link[base]{integer} or \link[base]{character} vector 
 #' indicating the attribute for plotting. Default is 1.
 #' @param threshold A number. The TWDTW dissimilarity threshold, \emph{i.e.} the 

--- a/R/plotArea.R
+++ b/R/plotArea.R
@@ -59,7 +59,7 @@
 #' timeline = scan(system.file("lucc_MT/data/timeline", package="dtwSat"), what="date")
 #' rts = twdtwRaster(evi, ndvi, red, blue, nir, mir, timeline = timeline, doy = doy)
 #' 
-#' # Read fiels samples 
+#' # Read field samples 
 #' field_samples = read.csv(system.file("lucc_MT/data/samples.csv", package="dtwSat"))
 #' proj_str = scan(system.file("lucc_MT/data/samples_projection", 
 #'                 package="dtwSat"), what = "character")

--- a/R/plotChanges.R
+++ b/R/plotChanges.R
@@ -30,7 +30,7 @@
 #' @param class.labels A \link[base]{character} or \link[base]{numeric}
 #' vector with the labels of the raster values. It must have the same 
 #' length as class.levels. Default is NULL.
-#' @param class.colors a set of aesthetic values. It must have the same 
+#' @param class.colors A set of aesthetic values. It must have the same 
 #' length as class.levels. Default is NULL. See 
 #' \link[ggplot2]{scale_fill_manual} for details.
 #' 
@@ -77,7 +77,7 @@ plotChanges = function(x, time.levels=NULL, time.labels=NULL, class.levels=NULL,
 .plotChanges = function(x, time.levels, time.labels, class.levels, class.labels, class.colors){
 
   if(length(time.levels)<2)
-    stop("the length of time.levels is shorter than two")
+    stop("The length of time.levels is shorter than two")
   
   df = do.call("rbind", lapply(seq_along(time.levels)[-1], function(l){
     from = raster::subset(x=x, subset=time.levels[l-1])[]

--- a/R/plotClassification.R
+++ b/R/plotClassification.R
@@ -20,15 +20,15 @@
 #' subinterval of the time series based on TWDTW analysis. 
 #' 
 #' @param x An object of class \code{\link[dtwSat]{twdtwMatches}}.
-#' @param timeseries.labels the label or index of the time series.
+#' @param timeseries.labels The label or index of the time series.
 #' Default is 1. 
-#' @param patterns.labels a vector with labels of the patterns. If not 
+#' @param patterns.labels A vector with labels of the patterns. If not 
 #' declared the function will plot one alignment for each pattern.
 #' 
 #' @param attr An \link[base]{integer} vector or \link[base]{character} vector 
 #' indicating the attribute for plotting. If not declared the function will plot 
 #' all attributes.
-#' @param ... additional arguments passed to \code{\link[dtwSat]{twdtwClassify}}.
+#' @param ... Additional arguments passed to \code{\link[dtwSat]{twdtwClassify}}.
 #' 
 #' @return A \link[ggplot2]{ggplot} object.
 #' 

--- a/R/plotCostMatrix.R
+++ b/R/plotCostMatrix.R
@@ -21,9 +21,9 @@
 #' 
 #' 
 #' @param x An object of class \code{\link[dtwSat]{twdtwMatches}}.
-#' @param timeseries.labels the label or index of the time series.
+#' @param timeseries.labels The label or index of the time series.
 #' Default is 1. 
-#' @param patterns.labels a vector with labels of the patterns. If not 
+#' @param patterns.labels A vector with labels of the patterns. If not 
 #' declared the function will plot one alignment for each pattern.
 #' @param matrix.name A character. The name of the matrix to plot,
 #' "costMatrix" for accumulated cost, "localMatrix" for local cost, 
@@ -65,7 +65,7 @@ plotCostMatrix = function(x, timeseries.labels=NULL, patterns.labels=NULL, matri
   ## Get data
   internals = getInternals(x)[[1]]
   if(any(sapply(internals, function(x) length(x$internals))<1))
-    stop("plot methods requires internals, set keep=TRUE on twdtwApply() call")
+    stop("Plot methods requires internals, set keep=TRUE on twdtwApply() call")
   ts = getTimeSeries(x)[[1]]
   patterns = getPatterns(x)
   

--- a/R/plotMapSamples.R
+++ b/R/plotMapSamples.R
@@ -5,9 +5,9 @@
 #' @description Method for plotting maps and samples.
 #' 
 #' @param x An object of class \code{\link[dtwSat]{twdtwAssessment}}.
-#' @param samples a character defining the samples to plot 
+#' @param samples A character defining the samples to plot 
 #' "correct", "incorrect", "all". Default is "all".
-#' @param ... other arguments to pass to \code{\link[dtwSat]{twdtwRaster}}
+#' @param ... Other arguments to pass to \code{\link[dtwSat]{twdtwRaster}}
 #' 
 #' @return A \link[ggplot2]{ggplot} object.
 #' 

--- a/R/plotMaps.R
+++ b/R/plotMaps.R
@@ -30,7 +30,7 @@
 #' @param class.labels A \link[base]{character} or \link[base]{numeric}
 #' vector with the labels of the raster values. It must have the same 
 #' length as class.levels. Default is NULL.
-#' @param class.colors a set of aesthetic values. It must have the same 
+#' @param class.colors A set of aesthetic values. It must have the same 
 #' length as class.levels. Default is NULL. See 
 #' \link[ggplot2]{scale_fill_manual} for details.
 #' 

--- a/R/plotMatches.R
+++ b/R/plotMatches.R
@@ -20,18 +20,18 @@
 #' TWDTW analysis.
 #' 
 #' @param x An object of class \code{\link[dtwSat]{twdtwMatches}}.
-#' @param timeseries.labels the label or index of the time series.
+#' @param timeseries.labels The label or index of the time series.
 #' Default is 1. 
-#' @param patterns.labels a vector with labels of the patterns. If not 
+#' @param patterns.labels A vector with labels of the patterns. If not 
 #' declared the function will plot one alignment for each pattern.
 #' @param k A positive integer. The index of the last alignment to include in 
 #' the plot. If not declared the function will plot the best match for 
 #' each pattern. 
 #' @param attr An \link[base]{integer} or \link[base]{character} vector 
 #' indicating the attribute for plotting. Default is 1.
-#' @param shift A number, it shifts the pattern position in the \code{x}
+#' @param shift A number that shifts the pattern position in the \code{x}
 #' direction. Default is 0.5.
-#' @param show.dist show the distance for each alignment. Default is FALSE.
+#' @param show.dist Show the distance for each alignment. Default is FALSE.
 #' @docType methods
 #' 
 #' @return A \link[ggplot2]{ggplot} object.
@@ -65,7 +65,7 @@ plotMatches = function(x, timeseries.labels=1, patterns.labels=NULL, k=1, attr=1
   ## Get data
   internals = getInternals(x)[[1]]
   if(any(sapply(internals, function(x) length(x$internals))<1))
-    stop("plot methods requires internals, set keep=TRUE on twdtwApply() call")
+    stop("Plot methods requires internals, set keep=TRUE on twdtwApply() call")
   matching = getMatches(x)[[1]]
   alignments = getAlignments(x)[[1]]
   ts = getTimeSeries(x)[[1]]
@@ -77,7 +77,7 @@ plotMatches = function(x, timeseries.labels=1, patterns.labels=NULL, k=1, attr=1
     k = unlist(lapply(table(y), function(i) seq(from=1, to=i) ))
   }
   if(length(y)!=length(k))
-    stop("if length of k greater than 1, then patterns.labels must have the same length as k.")
+    stop("If length of k greater than 1, then patterns.labels must have the same length as k.")
   
   xx = ts[,attr,drop=FALSE]
   tx = index(xx)
@@ -95,7 +95,7 @@ plotMatches = function(x, timeseries.labels=1, patterns.labels=NULL, k=1, attr=1
     ty = index(yy)
     
     if(k[i]>alignments[[p]]$K){
-      warning("alignment index out of bounds", call. = TRUE)
+      warning("Alignment index out of bounds", call. = TRUE)
       return(NULL)
     }
       

--- a/R/plotPaths.R
+++ b/R/plotPaths.R
@@ -21,9 +21,9 @@
 #' 
 #' 
 #' @param x An object of class \code{\link[dtwSat]{twdtwMatches}}.
-#' @param timeseries.labels the label or index of the time series.
+#' @param timeseries.labels The label or index of the time series.
 #' Default is 1. 
-#' @param patterns.labels a vector with labels of the patterns. If not 
+#' @param patterns.labels A vector with labels of the patterns. If not 
 #' declared the function will plot one alignment for each pattern.
 #' @param k A positive integer. The index of the last alignment to include in 
 #' the plot. If not declared the function will plot all low cost paths. 
@@ -58,7 +58,7 @@ plotPaths = function(x, timeseries.labels=NULL, patterns.labels=NULL, k=NULL){
   ## Get data
   internals = getInternals(x)[[1]]
   if(any(sapply(internals, function(x) length(x$internals))<1))
-    stop("plot methods requires internals, set keep=TRUE on twdtwApply() call")
+    stop("Plot methods requires internals, set keep=TRUE on twdtwApply() call")
   matching = getMatches(x)[[1]]
   ts = getTimeSeries(x)[[1]]
   patterns = getPatterns(x)

--- a/R/plotPatterns.R
+++ b/R/plotPatterns.R
@@ -20,10 +20,10 @@
 #' 
 #' @param x An object of class \code{\link[dtwSat]{twdtwTimeSeries}}, 
 #' \code{\link[zoo]{zoo}}, or list of \code{\link[zoo]{zoo}}.
-#' @param labels a vector with labels of the time series. If not declared 
+#' @param labels A vector with labels of the time series. If not declared 
 #' the function will plot all time series. 
 #' @param year An integer. The base year to shift the dates of the time series to. 
-#' If NULL then it does not shif the time series. Default is 2005. 
+#' If NULL then the time series is not shifted. Default is 2005. 
 #' @param attr An \link[base]{integer} vector or \link[base]{character} vector 
 #' indicating the attribute for plotting. If not declared the function will plot 
 #' all attributes.

--- a/R/plotTimeSeries.R
+++ b/R/plotTimeSeries.R
@@ -19,8 +19,8 @@
 #' @description Method for plotting the temporal patterns.
 #' 
 #' @param x An object of class \code{\link[dtwSat]{twdtwTimeSeries}}, 
-#' \code{\link[zoo]{zoo}}, or list of \code{\link[zoo]{zoo}}.
-#' @param labels a vector with labels of the time series. If missing, all 
+#' \code{\link[zoo]{zoo}}, or list of class \code{\link[zoo]{zoo}}.
+#' @param labels A vector with labels of the time series. If missing, all 
 #' elements in the list will be plotted (up to a maximum of 16).
 #' @param attr An \link[base]{integer} vector or \link[base]{character} vector 
 #' indicating the attribute for plotting. If not declared the function will plot 

--- a/R/resampleTimeSeries.R
+++ b/R/resampleTimeSeries.R
@@ -17,11 +17,10 @@
 #' @name resampleTimeSeries
 #' @author Victor Maus, \email{vwmaus1@@gmail.com}
 #' 
-#' @description resample time series in the same object to have the same 
-#' the length. 
+#' @description Resample time series in the object to have the same length. 
 #' 
 #' @inheritParams twdtwTimeSeries-class
-#' @param length An integer. The number of samples to resample the time series. 
+#' @param length An integer. The number of samples to resample the time series to. 
 #' If not declared the length is set to the length of the longest time series.
 #' 
 #' @seealso 

--- a/R/subset.R
+++ b/R/subset.R
@@ -27,17 +27,17 @@
 #' @param e An extent object, or any object from which an Extent object can
 #' be extracted. See \link[raster]{crop} for details.
 #' 
-#' @param layers a vector with the names of the \code{twdtwRaster} object to include in 
+#' @param layers A vector with the names of the \code{twdtwRaster} object to include in 
 #' the subset.
 #' 
-#' @param labels character vector with time series labels.
+#' @param labels A character vector with time series labels.
 #' 
 #' @seealso 
 #' \code{\link[dtwSat]{twdtwRaster-class}}, 
 #' \code{\link[dtwSat]{twdtwTimeSeries-class}}, and 
 #' \code{\link[dtwSat]{twdtwMatches-class}}
 #'
-#' @return an object of class twdtw*. 
+#' @return An object of class twdtw*. 
 #'
 #' @examples
 #' # Getting time series from objects of class twdtwTimeSeries
@@ -49,7 +49,7 @@
 #' mat = twdtwApply(x=ts, y=patt, weight.fun=logisticWeight(-0.1,100))
 #' mat = subset(mat, k=4)
 #' 
-#' ## This example creates a twdtwRaster object and extract time series from it. 
+#' ## This example creates a twdtwRaster object and extracts time series from it. 
 #'
 #' # Creating objects of class twdtwRaster with evi and ndvi time series 
 #' evi = brick(system.file("lucc_MT/data/evi.tif", package="dtwSat"))
@@ -66,7 +66,7 @@
 #' # Extract time series 
 #' ts_evi = getTimeSeries(rts_evi, y = field_samples, proj4string = prj_string)
 #' 
-#' # subset all labels = "Forest"
+#' # Subset all labels = "Forest"
 #' ts_forest = subset(ts_evi, labels="Forest")
 #' 
 NULL

--- a/R/twdtw.R
+++ b/R/twdtw.R
@@ -62,7 +62,7 @@
     I = order(candidates$d)
     if(length(I)<1) return(NULL)
     
-    # Sellect alignments 
+    # Select alignments 
     if(is.null(n)) n = length(I)
     if(length(I) > n) I = I[1:n]
     
@@ -76,7 +76,7 @@
     alignments$from       = tx[candidates$a[I]] # This is a vector of Dates
     alignments$to         = tx[candidates$b[I]] # This is a vector of Dates
     alignments$distance   = candidates$d[I]     # This is a numeric vector 
-    alignments$K          = length(I)           # This is an interger 
+    alignments$K          = length(I)           # This is an integer 
     alignments$matching   = list()              # This is a list of data.frames with the matching points 
     alignments$internals  = list()              # These is a list variables used in the TWDTW computation
     if(alignments$K<1) alignments$label = numeric(0)

--- a/R/twdtwApply.R
+++ b/R/twdtwApply.R
@@ -23,23 +23,23 @@
 #' 
 #' @inheritParams twdtwClassify
 #' 
-#' @param x an object of class twdtw*. This is the target time series. 
+#' @param x An object of class twdtw*. This is the target time series. 
 #' Usually, it is a set of unclassified time series. 
 #'
-#' @param y an object of class \link[dtwSat]{twdtwTimeSeries}. 
+#' @param y An object of class \link[dtwSat]{twdtwTimeSeries}. 
 #' The temporal patterns. 
 #' 
-#' @param ... arguments to pass to \code{\link[raster]{writeRaster}} and 
+#' @param ... Arguments to pass to \code{\link[raster]{writeRaster}} and 
 #' \code{\link[raster]{pbCreate}}
 #'
-#' @param resample resample the patterns to have the same length. Default is TRUE.
+#' @param resample Resample the patterns to have the same length. Default is TRUE.
 #' See \link[dtwSat]{resampleTimeSeries} for details.
 #' 
-#' @param length An integer. Patterns length used with \code{patterns.length}. 
+#' @param length An integer. Length of patterns used with \code{patterns.length}. 
 #' If not declared the length of the output patterns will be the length of 
 #' the longest pattern.
 #'  
-#' @param weight.fun A function. Any function that receive and performs a 
+#' @param weight.fun A function. Any function that receives and performs a 
 #' computation on a matrix. The function receives a matrix of time differences 
 #' in days and returns a matrix of time-weights. If not declared the time-weight 
 #' is zero. In this case the function runs the standard version of the dynamic 
@@ -49,29 +49,29 @@
 #' Default is ''Euclidean'' see \code{\link[proxy]{dist}} in package 
 #' \pkg{proxy}.
 #' 
-#' @param step.matrix see \code{\link[dtw]{stepPattern}} in package \pkg{dtw} [2].
+#' @param step.matrix See \code{\link[dtw]{stepPattern}} in package \pkg{dtw} [2].
 #' 
 #' @param n An integer. The maximun number of matches to perform. 
 #' NULL will return all matches.
 #' 
-#' @param theta numeric between 0 and 1. The weight of the time 
+#' @param theta Numeric between 0 and 1. The weight of the time 
 #' for the TWDTW computation. Use \code{theta=0} to cancel the time-weight, 
 #' \emph{i.e.} to run the original DTW algorithm. Default is 0.5, meaning that 
 #' the time has the same weight as the curve shape in the TWDTW analysis.
 #' 
-#' @param keep preserves the cost matrix, inputs, and other internal structures. 
+#' @param keep Preserves the cost matrix, inputs, and other internal structures. 
 #' Default is FALSE. For plot methods use \code{keep=TRUE}.
 #' 
 #' @param span A number. Span between two matches, \emph{i.e.} the minimum  
-#' interval between two matches, for details see [3]. If not declared it removes
+#' interval between two matches; for details see [3]. If not declared it removes
 #' all overlapping matches of the same pattern. To include overlapping matches 
 #' of the same pattern use \code{span=0}.
 #' 
-#' @param min.length A number between 0 an 1. This argument removes the over fittings.
+#' @param min.length A number between 0 an 1. This argument removes overfittings.
 #' Minimum length after warping. Percentage of the original pattern length. Default is 0.5, 
 #' meaning that the matching cannot be shorter than half of the pattern length.
 #' 
-#' @param filepath A character. The path to save the raster with results. If not informed the 
+#' @param filepath A character. The path at which to save the raster with results. If not provided the 
 #' function saves in the current work directory. 
 #' 
 #' @references 
@@ -89,7 +89,7 @@
 #' @details The linear \code{linearWeight} and \code{logisticWeight} weight functions 
 #' can be passed to \code{twdtwApply} through the argument \code{weight.fun}. This will 
 #' add a time-weight to the dynamic time warping analysis. The time weight 
-#' creates a global constraint useful to analyse time series with phenological cycles
+#' creates a global constraint useful for analysing time series with phenological cycles
 #' of vegetation that are usually bound to seasons. In previous studies by [1] the 
 #' logistic weight had better results than the linear for land cover classification. 
 #' See [1] for details about the method. 
@@ -260,7 +260,7 @@ twdtwApply.twdtwRaster = function(x, y, weight.fun, dist.method, step.matrix, n,
                                         step.matrix = step.matrix, n = n, span = span,
                                         min.length = min.length, theta = theta, keep = FALSE)
     
-    # Get best mathces for each point, period, and pattern
+    # Get best matches for each point, period, and pattern
     m <- length(levels)
     h <- length(breaks) - 1
     

--- a/R/twdtwApplyParallel.R
+++ b/R/twdtwApplyParallel.R
@@ -21,10 +21,10 @@
 #' [3] Muller, M. (2007). Dynamic Time Warping. In Information Retrieval for Music 
 #' and Motion (pp. 79-84). London: Springer London, Limited.
 #' 
-#' @details The linear \code{linearWeight} and \code{logisticWeight} weight functions 
+#' @details The \code{linearWeight} and \code{logisticWeight} weight functions 
 #' can be passed to \code{twdtwApply} through the argument \code{weight.fun}. This will 
 #' add a time-weight to the dynamic time warping analysis. The time weight 
-#' creates a global constraint useful to analyse time series with phenological cycles
+#' creates a global constraint useful for analysing time series with phenological cycles
 #' of vegetation that are usually bound to seasons. In previous studies by [1] the 
 #' logistic weight had better results than the linear for land cover classification. 
 #' See [1] for details about the method. 
@@ -162,7 +162,7 @@ twdtwApplyParallel.twdtwRaster = function(x, y, weight.fun, dist.method, step.ma
                                        step.matrix = step.matrix, n = n, span = span,
                                        min.length = min.length, theta = theta, keep = FALSE)
 
-    # Get best mathces for each point, period, and pattern
+    # Get best matches for each point, period, and pattern
     levels <- dtwSat::levels(y)
     m <- length(levels)
     h <- length(breaks)-1

--- a/R/twdtwAssess.R
+++ b/R/twdtwAssess.R
@@ -13,41 +13,41 @@ setGeneric("twdtwAssess",
 #' and estimated area according to [1-2]. The function returns the metrics 
 #' for each time interval and a summary considering all classified intervals. 
 #' 
-#' @param object an object of class \code{\link[dtwSat]{twdtwRaster}} resulting from 
+#' @param object An object of class \code{\link[dtwSat]{twdtwRaster}} resulting from 
 #' the classification, i.e. \code{\link[dtwSat]{twdtwClassify}}.
-#' The argument can also receive an error matrix (confusion matrix) in using the classes 
+#' The argument can also receive an error matrix (confusion matrix) using the classes 
 #' \code{\link[base]{data.frame}} or \code{\link[base]{table}}. In this case the user 
-#' must inform the area for each class to the argument \code{area}. 
+#' must provide the area for each class to the argument \code{area}. 
 #' 
-#' @param area a numeric vector with the area for each class if the argument \code{object}
+#' @param area A numeric vector with the area for each class if the argument \code{object}
 #' is an error matrix (confusion matrix). If \code{object} is \code{\link[dtwSat]{twdtwMatches}} 
 #' area can be either a vector with the area of each classified object, or a single number 
 #' if the objects are single pixels. 
 
-#' @param y a \code{\link[base]{data.frame}} whose attributes are: longitude, 
+#' @param y A \code{\link[base]{data.frame}} whose attributes are: longitude, 
 #' latitude, the start ''from'' and the end ''to'' of the time interval 
 #' for each sample. This can also be a \code{\link[sp]{SpatialPointsDataFrame}} 
 #' whose attributes are the start ''from'' and the end ''to'' of the time interval.
 #' If missing ''from'' and/or ''to'', they are set to the time range of the 
 #' \code{object}. 
 #' 
-#' @param id.labels a numeric or character with an column name from \code{y} to 
+#' @param id.labels A numeric or character with an column name from \code{y} to 
 #' be used as samples labels. Optional.
 #' 
-#' @param labels character vector with time series labels. For signature 
+#' @param labels Character vector with time series labels. For signature 
 #' \code{\link[dtwSat]{twdtwRaster}} this argument can be used to set the 
 #' labels for each sample in \code{y}, or it can be combined with \code{id.labels} 
 #' to select samples with a specific label.
 #' 
-#' @param proj4string projection string, see \code{\link[sp]{CRS-class}}. Used 
+#' @param proj4string Projection string, see \code{\link[sp]{CRS-class}}. Used 
 #' if \code{y} is a \code{\link[base]{data.frame}}.
 #' 
-#' @param conf.int specifies the confidence level (0-1).
+#' @param conf.int Specifies the confidence level (0-1).
 #' 
-#' @param rm.nosample if sum of columns and sum of rows of the error matrix are zero 
+#' @param rm.nosample If sum of columns and sum of rows of the error matrix are zero 
 #' then remove class. Default is TRUE. 
 #' 
-#' @param start_date a date. Required if there is only one map to be assessed. Usually this is the 
+#' @param start_date A date. Required if there is only one map to be assessed. Usually this is the 
 #' first date of the timeline from satellite images. 
 #' 
 #' @references 
@@ -173,14 +173,14 @@ twdtwAssess.table = function(object, area, conf.int, rm.nosample){
 twdtwAssess.twdtwRaster = function(object, y, labels, id.labels, proj4string, conf.int, rm.nosample, start_date){
   
   if(rm.nosample)
-    warning("The argument rm.nosample is obsolete and will be removed from the next package release")
+    warning("The argument rm.nosample is obsolete and will be removed in the next package release")
   
   # Check control points 
   y = .adjustLabelID(y, labels, id.labels)
   if(!"from"%in%names(y))
-    stop("samples starting date not found, the argument 'y' must have a column called 'from'")
+    stop("Sample starting date not found, the argument 'y' must have a column called 'from'")
   if(!"to"%in%names(y))
-    stop("samples ending date not found, the argument 'y' must have a column called 'to'")
+    stop("Sample ending date not found, the argument 'y' must have a column called 'to'")
   y = .toSpatialPointsDataFrame(y, object, proj4string)
   
   # Get classified raster 
@@ -195,7 +195,7 @@ twdtwAssess.twdtwRaster = function(object, y, labels, id.labels, proj4string, co
   if(length(timeline) < 2){
     if(is.null(start_date)){
       stop("The classification assessment requires matching time intervals. 
-           If there is only one map please inform the starting date of the map interval 
+           If there is only one map please provide the starting date of the map interval 
            using the argument 'start_date'")
     }
     timeline = c(as.Date(start_date), timeline)

--- a/R/twdtwClassify.R
+++ b/R/twdtwClassify.R
@@ -23,14 +23,14 @@
 #' 
 #' @inheritParams get
 #'
-#' @param x an object of class twdtw*. This is the target time series. 
+#' @param x An object of class twdtw*. This is the target time series. 
 #' Usually, it is a set of unclassified time series. 
 #' 
 #' @param from A character or \code{\link[base]{Dates}} object in the format "yyyy-mm-dd".
 #' 
 #' @param to A \code{\link[base]{character}} or \code{\link[base]{Dates}} object in the format "yyyy-mm-dd".
 #' 
-#' @param by A \code{\link[base]{character}} with the intevals size, \emph{e.g.} "6 month".
+#' @param by A \code{\link[base]{character}} with the interval size, \emph{e.g.} "6 month".
 #' 
 #' @param breaks A vector of class \code{\link[base]{Dates}}. This replaces the arguments \code{from},
 #' \code{to}, and \code{by}.
@@ -43,14 +43,14 @@
 #' The TWDTW dissimilarity thresholds, i.e. the maximum TWDTW cost for consideration 
 #' in the classification. Default is \code{Inf} for all \code{patterns.labels}.
 #' 
-#' @param fill a character or value to fill the classification gaps. 
-#' For signature \code{twdtwTimeSeries} the default is \code{fill="unclassified"}, and 
+#' @param fill A character to fill the classification gaps. 
+#' For signature \code{twdtwTimeSeries} the default is \code{fill="unclassified"}, 
 #' for signature \code{twdtwRaster} the default is \code{fill="unclassified"}.
 #' 
-#' @param filepath A character. The path to save the raster with results. If not informed the 
-#' function saves in the same directory as the input time series raster. 
+#' @param filepath A character. The path at which to save the raster with results. 
+#' If not provided the function saves in the same directory as the input time series raster. 
 #'  
-#' @param ... arguments to pass to specifique methods for each twdtw* class 
+#' @param ... Arguments to pass to specific methods for each twdtw* class 
 #' and other arguments to pass to \code{\link[raster]{writeRaster}} and 
 #' \code{\link[raster]{pbCreate}}. 
 #'
@@ -80,7 +80,7 @@ setMethod("twdtwClassify", "twdtwMatches",
                     if( !is.null(from) &  !is.null(to) ){
                       breaks = seq(as.Date(from), as.Date(to), by=by)    
                     } else {
-                      # This automatic breaks needs to be improved 
+                      # These automatic breaks needs to be improved 
                       y = x@patterns
                       patt_range = lapply(index(y), range)
                       patt_diff = trunc(sapply(patt_range, diff)/30)+1

--- a/R/twdtwCrossValidate.R
+++ b/R/twdtwCrossValidate.R
@@ -8,18 +8,18 @@ setGeneric("twdtwCrossValidate",
 #' @author Victor Maus, \email{vwmaus1@@gmail.com}
 #' 
 #' @description Splits the set of time series into training and validation and 
-#' compute accuracy metrics. The function uses stratified sampling and a simple 
+#' computes accuracy metrics. The function uses stratified sampling and a simple 
 #' random sampling for each stratum. For each data partition this function 
 #' performs a TWDTW analysis and returns the Overall Accuracy, User's Accuracy, 
 #' Produce's Accuracy, error matrix (confusion matrix), and a \code{\link[base]{data.frame}} 
 #' with the classification (Predicted), the reference classes (Reference), 
 #' and the results of the TWDTW analysis.
 #'
-#' @param object an object of class \code{\link[dtwSat]{twdtwTimeSeries}}.
+#' @param object An object of class \code{\link[dtwSat]{twdtwTimeSeries}}.
 #' 
 #' @param times Number of partitions to create.
 #' 
-#' @param p the percentage of data that goes to training. 
+#' @param p The percentage of data that goes to training. 
 #' See \code{\link[caret]{createDataPartition}} for details.
 #' 
 #' @param ... Other arguments to be passed to \code{\link[dtwSat]{createPatterns}} and 

--- a/R/twdtwXtable.R
+++ b/R/twdtwXtable.R
@@ -2,44 +2,44 @@ setGeneric("twdtwXtable",
            def = function(object, ...) standardGeneric("twdtwXtable")
 )
 
-#' @title Latex table from accuracy metrics
+#' @title LaTeX table from accuracy metrics
 #' @name twdtwXtable
 #' @author Victor Maus, \email{vwmaus1@@gmail.com}
 #'  
-#' @description Creates Latex table from accuracy metrics
+#' @description Creates LaTeX table from accuracy metrics
 #' 
 #' @inheritParams twdtwAssessment-class
 #' 
-#' @param table.type table type, 'accuracy' for User's and Producer's Accuracy, 
+#' @param table.type Table type, 'accuracy' for User's and Producer's Accuracy, 
 #' 'errormatrix' for error matrix, and 'area' for area and uncertainty. 
 #' Default is 'accuracy'.
 #' 
-#' @param time.labels a character or numeric for the time period or NULL to 
+#' @param time.labels A character or numeric for the time period or NULL to 
 #' include all classified periods. Default is NULL. 
 #' 
-#' @param category.name a character vector defining the class names. If NULL
-#' then use the classe names in the object \code{x}. Default is NULL.
+#' @param category.name A character vector defining the class names. If NULL
+#' the class names in the object \code{x} are used. Default is NULL.
 #' 
-#' @param category.type a character defining the categories type "numeric" 
-#' or "letter", if NULL then use the class names. Default is NULL. 
+#' @param category.type A character defining the categories type "numeric" 
+#' or "letter", if NULL the class names are used. Default is NULL. 
 #' 
-#' @param show.prop if TRUE shows the estimated proportion of area.
+#' @param show.prop If TRUE shows the estimated proportion of area.
 #' Used with \code{table.type='accuracy'}. Default is TRUE. 
 #' 
-#' @param show.overall if TRUE shows the overall accuracy of the cross-validation.
+#' @param show.overall If TRUE shows the overall accuracy of the cross-validation.
 #' Default is TRUE. 
 #' 
-#' @param rotate.col rotate class column names in latex table. Default is FALSE. 
+#' @param rotate.col Rotate class column names in latex table. Default is FALSE. 
 #' 
-#' @param caption the table caption. 
+#' @param caption The table caption. 
 #' 
-#' @param digits number of digits to show. 
+#' @param digits Number of digits to show. 
 #' 
-#' @param conf.int specifies the confidence level (0-1).
+#' @param conf.int Specifies the confidence level (0-1).
 #' 
-#' @param show.footnote show confidence interval in the footnote. 
+#' @param show.footnote Show confidence interval in the footnote. 
 #' 
-#' @param ... other arguments to pass to and \code{\link[xtable]{print.xtable}}.
+#' @param ... Other arguments to pass to \code{\link[xtable]{print.xtable}}.
 #'
 #' @seealso \code{\link[dtwSat]{twdtwAssess}} and  
 #' \code{\link[dtwSat]{twdtwAssessment}}.
@@ -58,7 +58,7 @@ setGeneric("twdtwXtable",
 #' timeline = scan(system.file("lucc_MT/data/timeline", package="dtwSat"), what="date")
 #' rts = twdtwRaster(evi, ndvi, red, blue, nir, mir, timeline = timeline, doy = doy)
 #' 
-#' # Read fiels samples 
+#' # Read field samples 
 #' field_samples = read.csv(system.file("lucc_MT/data/samples.csv", package="dtwSat"))
 #' proj_str = scan(system.file("lucc_MT/data/samples_projection", 
 #'                 package="dtwSat"), what = "character")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,7 +14,7 @@
 
 .onAttach = function(lib, pkg){
   packageStartupMessage(
-    sprintf("Loaded dtwSat v%s. See ?dtwSat for help, citation(\"dtwSat\") for use in publication.\n",
+    sprintf("Loaded dtwSat v%s. See ?dtwSat for help; citation(\"dtwSat\") for use in publications.\n",
             utils::packageDescription("dtwSat")$Version) )
   
   ## Register TWDTW as a distance function into package proxy


### PR DESCRIPTION
Mostly typos in documentation, some in errors and warnings.

Best typo:
> #' @param year the base year to shit the time series. 